### PR TITLE
Make clear that lua binary is not enough

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ This module requires these other modules and libraries:
 
     Inline
     Test::More
-    Lua 5.0	(this module actually tested on 5.0.2)
+    Lua 5.0	library and header files (this module actually tested on 5.0.2)
     C compiler
 
 COPYRIGHT AND LICENCE


### PR DESCRIPTION
It may not be clear that this module requires not a lua compiler as binary but the lua library and header files. For instance Ubuntu has lua50 package and a liblua50-dev package.

By the way, packaging the Lua source code (only 1.2MB) with this package, or giving instructions where to put the files from http://www.lua.org/source/, would simplify installation a lot!
