### PR TITLE
Support Lua 5.2

### DIFF
--- a/Lua.xs
+++ b/Lua.xs
@@ -516,16 +516,7 @@ interpreter (CLASS, ...)
 	    if (!INTERPRETER) {
 		RETVAL = INTERPRETER = luaL_newstate();
 		if (INTERPRETER) {
-#if LUA_VERSION_NUM >= 501
 		    luaL_openlibs(INTERPRETER);
-#else
-		    luaopen_base(INTERPRETER);
-		    luaopen_table(INTERPRETER);
-		    luaopen_io(INTERPRETER);
-		    luaopen_string(INTERPRETER);
-		    luaopen_debug(INTERPRETER);
-		    luaopen_loadlib(INTERPRETER);
-#endif
 		}
 	    }
 	    else

--- a/Lua.xs
+++ b/Lua.xs
@@ -16,7 +16,6 @@
 
 /* Support Lua 5.2 */
 #if LUA_VERSION_NUM >= 502
-#define lua_open() luaL_newstate()
 #define lua_strlen(L,i) lua_rawlen(L, (i))
 #endif
 
@@ -515,7 +514,7 @@ interpreter (CLASS, ...)
 		from_file = SvPV(ST(1), n_a);
 
 	    if (!INTERPRETER) {
-		RETVAL = INTERPRETER = lua_open();
+		RETVAL = INTERPRETER = luaL_newstate();
 		if (INTERPRETER) {
 #if LUA_VERSION_NUM >= 501
 		    luaL_openlibs(INTERPRETER);

--- a/Lua.xs
+++ b/Lua.xs
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"

--- a/Lua.xs
+++ b/Lua.xs
@@ -22,7 +22,12 @@
 SV *UNDEF, *LuaNil, NIL;
 AV *INLINE_RETURN;
 
-int close_attempt  (lua_State *);
+/* Called when Lua >= 5.2 closes a Perl filehandle - We don't currently
+ * do anything with this.  So we end up leaking :stdio layers (as we
+ * also do with 5.1).
+ */
+static int close_attempt(lua_State *L) { return 0; }
+
 
 void push_ary	    (lua_State *, AV*);
 void push_hash	    (lua_State *, HV*);
@@ -173,13 +178,6 @@ push_io (lua_State *L, PerlIO *pio) {
     p->closef = &close_attempt;
     luaL_setmetatable(L, LUA_FILEHANDLE);
 #endif
-}
-
-/* Called when Lua >= 5.2 closes a Perl filehandle - We don't currently
- * do anything with this.  So we end up leaking :stdio layers.
- */
-int close_attempt(lua_State *L) {
-    return 0;
 }
 
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,8 @@ use Config;
         my @candidates = (
             'lua-config',
             'pkg-config lua',
+            'pkg-config lua5.2',
+            'pkg-config lua-5.2',
             'pkg-config lua5.1',
             'pkg-config lua-5.1',
         );

--- a/check.c
+++ b/check.c
@@ -2,11 +2,11 @@
 #include <lualib.h>
 #include <lauxlib.h>
 
-#if LUA_VERSION_NUM != 501
-# error "Lua 5.1 required"
+#if (LUA_VERSION_NUM < 501) || (LUA_VERSION_NUM > 502)
+# error "Lua 5.1 or 5.2 required"
 #endif
 
 int main (void) {
-    void *p = (void *) lua_getfenv;
+    void *p = (void *) lua_getfield;
     return 0;
 }

--- a/t/1_basic.t
+++ b/t/1_basic.t
@@ -32,7 +32,8 @@ end
 
 function take_any (...)
     local a = ''
-    for i = 1, table.getn(arg), 1 do
+    local arg={...}
+    for i = 1, #arg, 1 do
 	a = a..arg[i]
     end
     return a

--- a/t/4_filehandle.t
+++ b/t/4_filehandle.t
@@ -18,8 +18,9 @@ is_deeply([<$fh>], ["foo\n", "bar\n", "baz\n"]);
 __END__
 __Lua__
 function write_file (fh, ...)
-    for i = 1, table.getn(arg), 1 do
-	fh:write(arg[i], "\n")
+    local arg={...}
+    for i,v in ipairs(arg) do
+	fh:write(v, "\n")
     end
 end
 


### PR DESCRIPTION
Howdy, I got your module as part of the CPAN Pull Challenge.

In trying to install it on my machine, I found that it's fairly particular about which version of Lua is installed - it needs 5.1 while I had 5.2.  This patch adds support for 5.2, which required slight modifications to the code (the Lua API changed a bit) and to the test scripts (some scripts that work in 5.1 don't work in 5.2 without slight modifications).

I validated that the tests do pass on 5.1 as well.  Please let me know if you would like me to approach any of this a different way - I'm glad to refactor to fit your project appropriately.