### PR TITLE
Allow other PERL_MM_OPT parameters

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -62,7 +62,7 @@ use Config;
 
 my %makefile_params;
 
-unless($ENV{'PERL_MM_OPT'}) {
+unless($ENV{'PERL_MM_OPT'} && $ENV{'PERL_MM_OPT'} =~ /(INC|LIBS)(?![a-z])/i) {
     my ( $inc, $libs ) = get_lua_config();
 
     if (!$inc && !$libs ) {


### PR DESCRIPTION
It's not currently possible to pass PERL_MM_OPT options for the build unless also including LIBS and INC parameters. For example, I was trying to do the following:

    PERL_MM_OPT='NO_PACKLIST=1 NO_PERLLOCAL=1'  ...

but the build was failing without the paths and libraries specified manually. This patch fixes that.