### PR TITLE
Fix passing integers for lua 5.3

### DIFF
--- a/Lua.xs
+++ b/Lua.xs
@@ -128,7 +128,11 @@ push_ary (lua_State *L, AV *av) {
 
     for (i = 0; i <= av_len(av); i++) {
 	SV **ptr = av_fetch(av, i, FALSE);
+#if LUA_VERSION_NUM < 503
 	lua_pushnumber(L, (lua_Number)i+1);
+#else
+	lua_pushinteger(L, (lua_Integer)i+1);
+#endif
 	if (ptr)
 	    push_val(L, *ptr);
 	else
@@ -236,7 +240,11 @@ push_val (lua_State *L, SV *val) {
             if(SvROK(val)) {
                 push_ref(L, val);
             } else {
+#if LUA_VERSION_NUM < 503
                 lua_pushnumber(L, (lua_Number)SvIV(val));
+#else
+                lua_pushinteger(L, (lua_Integer)SvIV(val));
+#endif
             }
 	    return;
 	case SVt_NV:

--- a/t/1_basic.t
+++ b/t/1_basic.t
@@ -2,13 +2,14 @@ use Test::More;
 
 no warnings 'once';
 
-BEGIN { plan tests => 8 };
+BEGIN { plan tests => 9 };
 
 use Inline Lua	    => 'DATA',
 	   Undef    => 'undefined value';
 
 ok(1);
 ok(take_num(42) == 43,				    "num");
+ok(cast_int(42) eq "42X",			    "cast int");
 ok(abs(take_num(42.42) - 42.42) - 1 < 0.1,	    "num");
 ok(take_string("foo", "bar") eq "foobar",	    "string");
 ok(! defined take_nil($Inline::Lua::Nil),	    "nil");
@@ -20,6 +21,10 @@ __END__
 __Lua__
 function take_num (a)
     return a+1
+end
+
+function cast_int (a)
+    return a .. "X"
 end
 
 function take_string (a, b)


### PR DESCRIPTION
Lua 5.3 introduces an integer data type. This patch adds support for this to Inline::Lua, passing integers as true integers instead of doubles. This is especially important, as Lua 5.3 casts doubles that look like integers to a string with a suffix of ".0".

I'm unsure whether the patch for push_ary is also needed, and I couldn't find a way to test it, but it seemed like the correct thing to do. There is also num2string with uses the Lua number type instead of integer, but this doesn't seem to be affected and I think it is already tested.